### PR TITLE
Allow initialization without block

### DIFF
--- a/lib/adyen_cse/encrypter.rb
+++ b/lib/adyen_cse/encrypter.rb
@@ -13,7 +13,7 @@ module AdyenCse
 
     def initialize(public_key)
       @public_key = public_key
-      yield self
+      yield self rescue nil
       self.generation_time ||= Time.now
     end
 


### PR DESCRIPTION
Allow `#initialize` with this:
```ruby
cse = AdyenCse::Encrypter.new(public_key)
cse.holder_name = "Adyen Shopper"
cse.number      = "4111111111111111"
...
```
Instead of only this:
```ruby
cse = AdyenCse::Encrypter.new(public_key) do |card|
  card.holder_name  = "Adyen Shopper"
  card.number       = "4111111111111111"
  ...
end
```