### PR TITLE
Refactor initialization format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,22 @@ Or install it yourself as:
 ```ruby
 require 'adyen_cse'
 
-cse = AdyenCse::Encrypter.new(public_key) do |card|
-  card.holder_name  = "Adyen Shopper"
-  card.number       = "4111111111111111"
-  card.expiry_month = "08"
-  card.expiry_year  = "2018"
-  card.cvc          = "737"
-end
+cse = AdyenCse::Encrypter.new(public_key)
 
-encrypted_card = cse.encrypt!
+encrypted_card = cse.encrypt!(
+  holder_name: "Adyen Shopper",
+  number: 4111_1111_1111_1111.to_s,
+  expiry_month: "08",
+  expiry_year: "2018",
+  cvc: "737"
+)
+```
+
+Optionally, you may pass a custom `generation_time` to mock expired data.
+
+```ruby
+encrypted_card = cse.encrypt!(
+  ...,
+  generation_time: Time.new(2015, 10, 21)
+)
 ```

--- a/lib/adyen_cse/encrypter.rb
+++ b/lib/adyen_cse/encrypter.rb
@@ -5,8 +5,8 @@ require "json"
 
 module AdyenCse
   class Encrypter
-    PREFIX    = "adyenrb"
-    VERSION   = "0_1_1"
+    PREFIX  = "adyenrb"
+    VERSION = "0_1_1"
 
     attr_reader   :public_key
     attr_accessor :holder_name, :number, :expiry_month, :expiry_year, :cvc, :generation_time

--- a/lib/adyen_cse/encrypter.rb
+++ b/lib/adyen_cse/encrypter.rb
@@ -8,24 +8,31 @@ module AdyenCse
     PREFIX  = "adyenrb"
     VERSION = "0_1_1"
 
-    attr_reader   :public_key
-    attr_accessor :holder_name, :number, :expiry_month, :expiry_year, :cvc, :generation_time
+    attr_reader :public_key
 
     def initialize(public_key)
       @public_key = public_key
-      yield self rescue nil
-      self.generation_time ||= Time.now
     end
 
-    def encrypt!
-      validate!
+    def encrypt!(params = {})
+      validate!(params.keys)
 
       key   = SecureRandom.random_bytes(32)
       nonce = SecureRandom.random_bytes(12)
-      data  = card_data.to_json
+      generation_time = params.fetch(:generation_time, Time.now)
+
+      # keys sorted alphabetically
+      json_data = {
+        "cvc" => params[:cvc],
+        "expiryMonth" => params[:expiry_month],
+        "expiryYear" => params[:expiry_year],
+        "generationtime" => generation_time.utc.strftime("%FT%T.%LZ"),
+        "holderName" => params[:holder_name],
+        "number" => params[:number],
+      }.to_json
 
       ccm = OpenSSL::CCM.new("AES", key, 8)
-      encrypted_card = ccm.encrypt(data, nonce)
+      encrypted_card = ccm.encrypt(json_data, nonce)
 
       rsa = self.class.parse_public_key(public_key)
       encrypted_aes_key = rsa.public_encrypt(key)
@@ -33,18 +40,6 @@ module AdyenCse
       encrypted_card_component = nonce + encrypted_card
 
       [PREFIX, VERSION, "$", Base64.strict_encode64(encrypted_aes_key), "$", Base64.strict_encode64(encrypted_card_component)].join
-    end
-
-    def card_data
-      # keys sorted alphabetically
-      {
-        "cvc" => cvc,
-        "expiryMonth" => expiry_month,
-        "expiryYear" => expiry_year,
-        "generationtime" => generation_time.utc.strftime("%FT%T.%LZ"),
-        "holderName" => holder_name,
-        "number" => number,
-      }
     end
 
     def self.parse_public_key(public_key)
@@ -58,9 +53,9 @@ module AdyenCse
 
     private
 
-    def validate!
-      %w(holder_name number expiry_month expiry_year cvc generation_time).each do |param|
-        raise ArgumentError, "param `#{param}' is required" if instance_variable_get("@#{param}").nil?
+    def validate!(params)
+      %i(holder_name number expiry_month expiry_year cvc).each do |param|
+        raise ArgumentError, "param `#{param}' is required" unless params.include?(param)
       end
     end
   end

--- a/lib/adyen_cse/version.rb
+++ b/lib/adyen_cse/version.rb
@@ -1,3 +1,3 @@
 module AdyenCse
-  VERSION = "0.1.5"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Refactor from this:

```ruby
cse = AdyenCse::Encrypter.new(public_key) do |card|
  card.holder_name  = "Adyen Shopper"
  card.number       = "4111111111111111"
  card.expiry_month = "08"
  card.expiry_year  = "2018"
  card.cvc          = "737"
end
```

to this:

```ruby
cse = AdyenCse::Encrypter.new(public_key)

encrypted_card = cse.encrypt!(
  holder_name: "Adyen Shopper",
  number: 4111_1111_1111_1111.to_s,
  expiry_month: "08",
  expiry_year: "2018",
  cvc: "737"
)
```

Prefer the latter because it's clearer, and more ruby-like.
Also, an instance of `AdyenCse::Encrypter` should be able to encrypt multiple cards, multiple times.