### PR TITLE
Support for Ruby 2.4 RSA syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
+  - 2.4.4
+  - 2.5.1
 before_install: gem install bundler -v 1.14.6

--- a/lib/adyen_cse/encrypter.rb
+++ b/lib/adyen_cse/encrypter.rb
@@ -45,9 +45,14 @@ module AdyenCse
     def self.parse_public_key(public_key)
       exponent, modulus = public_key.split("|").map { |n| n.to_i(16) }
 
-      OpenSSL::PKey::RSA.new.tap do |rsa|
-        rsa.e = OpenSSL::BN.new(exponent)
-        rsa.n = OpenSSL::BN.new(modulus)
+      if RUBY_VERSION <= "2.3.1"
+        OpenSSL::PKey::RSA.new.tap do |rsa|
+          rsa.e = OpenSSL::BN.new(exponent)
+          rsa.n = OpenSSL::BN.new(modulus)
+        end
+      else
+        rsa = OpenSSL::PKey::RSA.new
+        rsa.set_key(OpenSSL::BN.new(modulus), OpenSSL::BN.new(exponent), nil)
       end
     end
 

--- a/lib/adyen_cse/version.rb
+++ b/lib/adyen_cse/version.rb
@@ -1,3 +1,3 @@
 module AdyenCse
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Fix #4 

TLDR;
As of Ruby 2.4, `OpenSSL::PKey::RSA` class changed, syntax changes. 
Update to use new syntax if ruby version > 2.3.1