### PR TITLE
Use official openssl-ccm gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in adyen_cse_ruby.gemspec
 gemspec
 
-gem "openssl-ccm", git: "https://github.com/jooeycheng/openssl-ccm", branch: "update-cipher-validation"
+gem "openssl-ccm"
 
 group :development do
   gem "pry"

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ Or install it yourself as:
 
     $ gem install adyen-cse-ruby
 
-## Known issue
-
-If you are facing error `OpenSSL::CCMError: unsupported cipher algorithm (AES)`, refer to [issue #11](https://github.com/jooeycheng/adyen-cse-ruby/issues/11).
-
 ## Usage
 
 ```ruby

--- a/adyen-cse-ruby.gemspec
+++ b/adyen-cse-ruby.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Temporary disabled until https://github.com/SmallLars/openssl-ccm/pull/4 is patched.
-  # spec.add_runtime_dependency "openssl-ccm"
+  spec.add_runtime_dependency "openssl-ccm"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/adyen_cse/version.rb
+++ b/lib/adyen_cse/version.rb
@@ -1,3 +1,3 @@
 module AdyenCse
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
Fix #11.

Wait for [openssl-ccm v1.2.2](https://rubygems.org/gems/openssl-ccm/versions) to be published.
Related: https://github.com/SmallLars/openssl-ccm/issues/5