### PR TITLE
update backward compatible up to 2.3.9

### DIFF
--- a/lib/adyen_cse/encrypter.rb
+++ b/lib/adyen_cse/encrypter.rb
@@ -45,7 +45,7 @@ module AdyenCse
     def self.parse_public_key(public_key)
       exponent, modulus = public_key.split("|").map { |n| n.to_i(16) }
 
-      if RUBY_VERSION <= "2.3.1"
+      if RUBY_VERSION < '2.4.0'
         OpenSSL::PKey::RSA.new.tap do |rsa|
           rsa.e = OpenSSL::BN.new(exponent)
           rsa.n = OpenSSL::BN.new(modulus)


### PR DESCRIPTION
Running this gem on 2.3.8 will get this issue:
```
NoMethodError:
--
4437 | undefined method `set_key' for #<OpenSSL::PKey::RSA:0x000055ff088e8908>
4438 | # ./spec/factories/adyen_test_card.rb:33:in `nonce'
```
Because 2.3.8 is still using old syntax but the version check is only up to 2.3.1.